### PR TITLE
feat(trust-info): adapt UI to verifier trust_info report

### DIFF
--- a/src/components/trust-info.tsx
+++ b/src/components/trust-info.tsx
@@ -2,65 +2,114 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { TrustInfo } from '../lib/types';
+import { CheckStatus, MsoMdocCheck, TrustInfo } from '../lib/types';
 
 interface TrustInfoDisplayProps {
-  trustInfo: TrustInfo[];
+  trustInfo: TrustInfo;
   isAgeOver18: boolean;
   usedDcApi: boolean;
   zkProofValidated?: boolean | null;
 }
 
+// Human-readable labels for the verifier's mso_mdoc check identifiers.
+const CHECK_LABELS: Record<MsoMdocCheck, string> = {
+  IssuerChainTrusted: 'Issuer is trusted',
+  IssuerSignatureValid: 'Issuer signature valid',
+  IssuerKeyIsEC: 'Issuer key is valid',
+  NotExpired: 'Issuer has not expired',
+  ValidityInfoPresent: 'Validity information present',
+  DocumentTypeMatches: 'Document type matches',
+  IssuerSignedItemsValid: 'Issuer-signed data integrity',
+  NotRevoked: 'Not revoked',
+  DeviceSignedPresent: 'Device-signed data present',
+  DeviceKeyAuthorized: 'Device key authorized',
+  DeviceKeyValid: 'Device key valid',
+  DeviceSignatureValid: 'Device signature valid',
+};
+
+// The curated subset of backend checks to display (in order). The verifier reports many more
+// checks, but only these are surfaced in the UI; the overall verdict still reflects all of them.
+const DISPLAYED_CHECKS: MsoMdocCheck[] = [
+  'IssuerChainTrusted',
+  'NotExpired',
+  'DeviceSignatureValid',
+];
+
+type DisplayCheck = {
+  label: string;
+  status: CheckStatus;
+  detail?: string;
+};
+
 interface TrustCheckItemProps {
   label: string;
-  isValid: boolean;
-  description?: string;
+  status: CheckStatus;
+  detail?: string;
 }
 
-function TrustCheckItem({ label, isValid, description }: TrustCheckItemProps) {
+const STATUS_BADGE: Record<CheckStatus, { text: string; className: string }> = {
+  passed: { text: 'Verified', className: 'bg-green-100 text-green-800' },
+  failed: { text: 'Not verified', className: 'bg-red-100 text-red-800' },
+  skipped: { text: 'Not checked', className: 'bg-gray-200 text-gray-600' },
+};
+
+function StatusIcon({ status }: { status: CheckStatus }) {
+  if (status === 'passed') {
+    return (
+      <div className="w-6 h-6 rounded-full flex items-center justify-center bg-green-100 text-green-600">
+        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+          <path
+            fillRule="evenodd"
+            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+    );
+  }
+  if (status === 'failed') {
+    return (
+      <div className="w-6 h-6 rounded-full flex items-center justify-center bg-red-100 text-red-600">
+        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+          <path
+            fillRule="evenodd"
+            d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+    );
+  }
+  return (
+    <div className="w-6 h-6 rounded-full flex items-center justify-center bg-gray-200 text-gray-500">
+      <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+        <path
+          fillRule="evenodd"
+          d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+          clipRule="evenodd"
+        />
+      </svg>
+    </div>
+  );
+}
+
+function TrustCheckItem({ label, status, detail }: TrustCheckItemProps) {
+  const badge = STATUS_BADGE[status];
   return (
     <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg border">
       <div className="flex-1">
         <div className="flex items-center gap-3">
-          <div
-            className={`w-6 h-6 rounded-full flex items-center justify-center ${
-              isValid
-                ? 'bg-green-100 text-green-600'
-                : 'bg-red-100 text-red-600'
-            }`}
-          >
-            {isValid ? (
-              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                <path
-                  fillRule="evenodd"
-                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ) : (
-              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                <path
-                  fillRule="evenodd"
-                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            )}
-          </div>
+          <StatusIcon status={status} />
           <div>
             <h3 className="font-medium text-gray-900">{label}</h3>
-            {description && (
-              <p className="text-sm text-gray-500 mt-1">{description}</p>
-            )}
+            {detail && <p className="text-sm text-gray-500 mt-1">{detail}</p>}
           </div>
         </div>
       </div>
       <div
-        className={`px-3 py-1 rounded-full text-xs font-medium ${
-          isValid ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
-        }`}
+        className={`px-3 py-1 rounded-full text-xs font-medium ${badge.className}`}
       >
-        {isValid ? 'Verified' : 'Not verified'}
+        {badge.text}
       </div>
     </div>
   );
@@ -71,40 +120,47 @@ export default function TrustInfoDisplay({
   isAgeOver18,
   zkProofValidated,
 }: TrustInfoDisplayProps) {
-  if (!trustInfo || trustInfo.length === 0) {
+  if (!trustInfo || trustInfo.documents.length === 0) {
     return null;
   }
 
-  const trust = trustInfo[0]; // Take the first trust info object
+  // The age-verification flow presents a single document.
+  const documentTrust = trustInfo.documents[0];
 
-  const checks = [
-    {
-      label: 'Issuer is trusted',
-      isValid: trust.issuer_in_trusted_list,
-      description: ``,
-    },
-    {
-      label: 'Issuer has not expired',
-      isValid: trust.issuer_in_trusted_list,
-      description: ``,
-    },
+  const backendChecks: DisplayCheck[] = DISPLAYED_CHECKS.filter(
+    (name) => documentTrust.checks[name] !== undefined
+  ).map((name) => {
+    const outcome = documentTrust.checks[name]!;
+    return {
+      label: CHECK_LABELS[name],
+      status: outcome.status,
+      detail: outcome.detail,
+    };
+  });
+
+  const derivedChecks: DisplayCheck[] = [
     {
       label: 'Age over 18 confirmed',
-      isValid: isAgeOver18,
-      description: '',
+      status: isAgeOver18 ? 'passed' : 'failed',
     },
   ];
 
   if (zkProofValidated !== null && zkProofValidated !== undefined) {
-    checks.push({
+    derivedChecks.push({
       label: 'ZK proof validated',
-      isValid: zkProofValidated,
-      description: zkProofValidated ? 'Successfully validated proof' : '',
+      status: zkProofValidated ? 'passed' : 'failed',
+      detail: zkProofValidated ? 'Successfully validated proof' : undefined,
     });
   }
 
-  const overallTrustScore = checks.filter((check) => check.isValid).length;
-  const totalChecks = checks.length;
+  const checks = [...backendChecks, ...derivedChecks];
+
+  // Skipped checks are excluded from the score: they were not performed.
+  const performedChecks = checks.filter((check) => check.status !== 'skipped');
+  const passedChecks = performedChecks.filter(
+    (check) => check.status === 'passed'
+  ).length;
+  const totalPerformed = performedChecks.length;
 
   return (
     <div className="w-full mt-8">
@@ -115,18 +171,22 @@ export default function TrustInfoDisplay({
         <div className="flex items-center gap-2 mb-4">
           <div
             className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
-              overallTrustScore === totalChecks
+              passedChecks === totalPerformed
                 ? 'bg-green-100 text-green-800'
-                : overallTrustScore > 0
+                : passedChecks > 0
                   ? 'bg-yellow-100 text-yellow-800'
                   : 'bg-red-100 text-red-800'
             }`}
           >
-            {overallTrustScore}/{totalChecks} checks passed
+            {passedChecks}/{totalPerformed} checks passed
           </div>
-          {trust.is_fully_trusted && (
+          {trustInfo.trusted ? (
             <div className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800">
               Fully trusted
+            </div>
+          ) : (
+            <div className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800">
+              Not fully trusted
             </div>
           )}
         </div>
@@ -137,22 +197,11 @@ export default function TrustInfoDisplay({
           <TrustCheckItem
             key={index}
             label={check.label}
-            isValid={check.isValid}
-            description={check.description}
+            status={check.status}
+            detail={check.detail}
           />
         ))}
       </div>
-
-      {trust.validation_errors && trust.validation_errors.length > 0 && (
-        <div className="mt-4 p-4 bg-red-50 border border-red-200 rounded-lg">
-          <h4 className="font-medium text-red-800 mb-2">Validation errors:</h4>
-          <ul className="list-disc list-inside text-sm text-red-700">
-            {trust.validation_errors.map((error, index) => (
-              <li key={index}>{error}</li>
-            ))}
-          </ul>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/hooks/use-age-verification.ts
+++ b/src/hooks/use-age-verification.ts
@@ -12,6 +12,7 @@ import {
   GetPresentationState,
 } from '../lib/presentation';
 import {
+  AV_NAMESPACE,
   DcApiDeviceResponse,
   PresentationFields,
   PresentationState,
@@ -41,7 +42,7 @@ export function useAgeVerification(useDcApi: boolean) {
   const [verifiedData, setVerifiedData] = useState<VerifiedAttribute[] | null>(
     null
   );
-  const [trustInfo, setTrustInfo] = useState<TrustInfo[] | null>(null);
+  const [trustInfo, setTrustInfo] = useState<TrustInfo | null>(null);
   const [usedDcApi, setUsedDcApi] = useState(false);
   const [showQrCode, setShowQrCode] = useState(false);
   const [zkProofValidated, setZkProofValidated] = useState<boolean | null>(
@@ -122,12 +123,26 @@ export function useAgeVerification(useDcApi: boolean) {
         const zkProofLine = allLines.find((line) => line.key === 'ZK proof');
         setZkProofValidated(zkProofLine ? true : false);
 
-        setTrustInfo([
-          {
-            issuer_in_trusted_list: isTrusted,
-            is_fully_trusted: isTrusted,
-          },
-        ] as TrustInfo[]);
+        setTrustInfo({
+          trusted: isTrusted,
+          documents: [
+            {
+              index: 0,
+              document_type: AV_NAMESPACE,
+              valid: isTrusted,
+              // The DC API path has no per-check report from the backend; it only
+              // exposes a single trusted/untrusted signal, mirrored onto both checks.
+              checks: {
+                IssuerChainTrusted: {
+                  status: isTrusted ? 'passed' : 'failed',
+                },
+                NotExpired: {
+                  status: isTrusted ? 'passed' : 'failed',
+                },
+              },
+            },
+          ],
+        });
 
         addLog('success', { response: data });
         return;

--- a/src/lib/dc-api.ts
+++ b/src/lib/dc-api.ts
@@ -57,6 +57,8 @@ async function beginDcApiSession(requestId: string): Promise<DcApiChallenge> {
       protocol: 'w3c_dc_mdoc_api',
       origin: window.location.origin,
       host: window.location.host,
+      multiDocumentRequestId: '',
+      rawDcql: '',
       signRequest: true,
       encryptResponse: true,
     }),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,14 +53,42 @@ export type PresentationFields = {
   path: string[];
 };
 
+// Verdict of a single validation check, as emitted by the verifier.
+export type CheckStatus = 'passed' | 'skipped' | 'failed';
+
+export type CheckOutcome = {
+  status: CheckStatus;
+  // Human-readable explanation, present for failed (and optionally skipped) checks.
+  detail?: string;
+};
+
+// The mso_mdoc check identifiers emitted by the verifier (MsoMdocCheck enum names).
+export type MsoMdocCheck =
+  | 'IssuerChainTrusted'
+  | 'ValidityInfoPresent'
+  | 'NotExpired'
+  | 'IssuerKeyIsEC'
+  | 'IssuerSignatureValid'
+  | 'DocumentTypeMatches'
+  | 'IssuerSignedItemsValid'
+  | 'NotRevoked'
+  | 'DeviceSignedPresent'
+  | 'DeviceKeyAuthorized'
+  | 'DeviceKeyValid'
+  | 'DeviceSignatureValid';
+
+export type DocumentTrustInfo = {
+  index: number;
+  document_type: string;
+  valid: boolean;
+  checks: Partial<Record<MsoMdocCheck, CheckOutcome>>;
+};
+
+// The per-check trust report returned under `trust_info` by the verifier's
+// get-wallet-response endpoint (only present when always-accept mode is enabled).
 export type TrustInfo = {
-  issuer_in_trusted_list: boolean;
-  issuer_not_expired: boolean;
-  trusted_list_source: string;
-  valid_from: string;
-  valid_until: string;
-  validation_errors: string[];
-  is_fully_trusted: boolean;
+  trusted: boolean;
+  documents: DocumentTrustInfo[];
 };
 
 export type PresentationState = {
@@ -76,7 +104,8 @@ export type PresentationState = {
       path: string;
     }>;
   };
-  trust_info: TrustInfo[];
+  // Present only when the verifier runs in always-accept mode.
+  trust_info?: TrustInfo;
 };
 
 export type DcApiChallenge = {
@@ -129,13 +158,13 @@ export type VerificationResult =
   | {
       source: 'dc-api';
       attributes: VerifiedAttribute[];
-      trust: TrustInfo[];
+      trust: TrustInfo | null;
       zkProofValidated: boolean;
     }
   | {
       source: 'openid4vp';
       attributes: VerifiedAttribute[];
-      trust: TrustInfo[];
+      trust: TrustInfo | null;
     };
 
 export type TransactionLogType =


### PR DESCRIPTION
## What

Adapts the trust report types and display to the verifier's get-wallet-response `trust_info` object (`{ trusted, documents[].checks }`), replacing the previous (speculative) flat `TrustInfo[]` shape.

- New types: `TrustInfo`, `DocumentTrustInfo`, `CheckOutcome`, `CheckStatus`, `MsoMdocCheck`.
- `TrustInfoDisplay` shows a curated set of per-check results (issuer trusted, issuer not expired, device signature valid) with `passed` / `skipped` / `failed` status, plus the derived "age over 18" and ZK checks.
- The Digital Credentials API path maps its single trusted/untrusted signal onto the same shape.

## Notes for reviewers

- This branch also carries a previously fork-only commit (`fix: add multiDocumentRequestId and rawDcql fields to session initiation`, touches `src/lib/dc-api.ts`).
- The `trust_info` object is emitted by the verifier-endpoint's always-accept mode; the corresponding backend support must be present for the report to appear.

Verified locally: `tsc -b` and `eslint` pass.
